### PR TITLE
이너뷰 컬쳐 영역 수정 관련 PR

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -410,9 +410,9 @@
 }
 
 .culture_item {
-  width: 332px;
+  width: 19%;
   height: 319px;
-  flex-shrink: 0;
+  flex: 1 0 336px;
   background-color: #1c1c1c;
   display: flex;
   flex-direction: column;
@@ -552,28 +552,6 @@
   .main_title {
     font-size: 32px;
   }
-
-  .culture_item {
-    width: 160px;
-    height: 160px;
-  }
-
-  .culture_item img {
-    width: 28px;
-    height: 28px;
-    flex-shrink: 0;
-    margin-bottom: 8px;
-  }
-
-  .item_name {
-    font-size: 14px;
-    margin-bottom: 0;
-  }
-
-  .item_desc {
-    font-size: 12px;
-    letter-spacing: -0.24px;
-  }
 }
 
 @media (max-width: 1170px) {
@@ -668,6 +646,28 @@
     font-size: 32px;
     line-height: 1.3;
     margin-bottom: 32px;
+  }
+
+  .culture_item {
+    height: 160px;
+    flex-basis: 160px;
+  }
+
+  .culture_item img {
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    margin-bottom: 8px;
+  }
+
+  .item_name {
+    font-size: 14px;
+    margin-bottom: 0;
+  }
+
+  .item_desc {
+    font-size: 12px;
+    letter-spacing: -0.24px;
   }
 }
 
@@ -764,12 +764,6 @@
     padding-right: 24px;
   }
 
-  .footer {
-    padding: 30px 24px 27px;
-  }
-}
-
-@media (max-width: 680px) {
   .sec_culture {
     padding: 0 24px 0 21px;
   }
@@ -777,6 +771,10 @@
   .culture_container {
     padding-left: 3px;
     gap: 8px 7px;
+  }
+
+  .footer {
+    padding: 30px 24px 27px;
   }
 }
 
@@ -843,18 +841,5 @@
 
   .position_title .recruit_status {
     margin: 0 10px 0 12px;
-  }
-}
-
-@media (min-width: 359px) and (max-width: 374px) {
-  .culture_item {
-    width: 152px;
-    height: 152px;
-  }
-}
-
-@media (max-width: 358px) {
-  .culture_container {
-    justify-content: center;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -410,9 +410,8 @@
 }
 
 .culture_item {
-  width: 19%;
   height: 319px;
-  flex: 1 0 336px;
+  flex: 1 0 24%;
   background-color: #1c1c1c;
   display: flex;
   flex-direction: column;
@@ -650,7 +649,7 @@
 
   .culture_item {
     height: 160px;
-    flex-basis: 160px;
+    flex: 1 0 33%;
   }
 
   .culture_item img {


### PR DESCRIPTION
자사 채용페이지 과제 피드백 후 이너뷰 컬쳐 영역 수정하여 PR 드립니다~!

브라우저 크기가 줄어들 때 텍스트가 줄바꿈되지 않는 마지노선으로 flex-basis의 퍼센테이지를 잡았는데,  
그렇게 하니 1920px에서 첫 줄에 4개가 나와 시안과 달라지는 문제가 생겼습니다ㅠㅠ  
flex: 1 0 336px로 설정하는 편이 좋았을까요..?
이와 관련하여 피드백 해주신다면 대단히 감사하겠습니다ㅠㅠ!!!
(flex는 왜 해도해도 어려울까요...집에서 개구리 게임을 100번 더 해야겠습니다😭)